### PR TITLE
Add jMolecules persistence generation as alternative approach

### DIFF
--- a/jmolecules.config
+++ b/jmolecules.config
@@ -1,0 +1,2 @@
+bytebuddy.include=com.mploed.aggregate.jmolecules, com.mploed.repository.jmolecules
+bytebuddy.persistence=jpa

--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,24 @@
 
     <properties>
         <java.version>21</java.version>
+        <jmolecules.version>2023.3.2</jmolecules.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jmolecules</groupId>
+                <artifactId>jmolecules-bom</artifactId>
+                <version>${jmolecules.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
 
@@ -58,9 +70,17 @@
         <dependency>
             <groupId>org.jmolecules</groupId>
             <artifactId>jmolecules-ddd</artifactId>
-            <version>1.9.0</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.jmolecules.integrations</groupId>
+            <artifactId>jmolecules-bytebuddy-nodep</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jmolecules.integrations</groupId>
+            <artifactId>jmolecules-jpa</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -101,7 +121,21 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-maven-plugin</artifactId>
+                <version>1.17.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>transform-extended</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <classPathDiscovery>true</classPathDiscovery>
+                </configuration>
+            </plugin>
 
         </plugins>
     </build>

--- a/src/main/java/com/mploed/aggregate/jmolecules/ApplicantScoringCluster.java
+++ b/src/main/java/com/mploed/aggregate/jmolecules/ApplicantScoringCluster.java
@@ -1,0 +1,75 @@
+package com.mploed.aggregate.jmolecules;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.jmolecules.ddd.types.AggregateRoot;
+import org.jmolecules.ddd.types.Identifier;
+
+import com.mploed.aggregate.jmolecules.ApplicantScoringCluster.ClusterIdentifier;
+
+/**
+ * @author Oliver Drotbohm
+ */
+public class ApplicantScoringCluster implements AggregateRoot<ApplicantScoringCluster, ClusterIdentifier> {
+
+	public record ClusterIdentifier(UUID id) implements Identifier {}
+
+	private final ClusterIdentifier id;
+	private final ApplicationNumber applicationNumber;
+	private City city;
+	private BalanceAtBank balance;
+
+	public ApplicantScoringCluster(ApplicationNumber applicationNumber) {
+
+		if (applicationNumber == null) {
+			throw new IllegalArgumentException("Antragsnummer darf nicht null sein.");
+		}
+
+		this.id = new ClusterIdentifier(UUID.randomUUID());
+		this.applicationNumber = applicationNumber;
+		this.balance = new BalanceAtBank(0);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.jmolecules.ddd.types.Identifiable#getId()
+	 */
+	@Override
+	public ClusterIdentifier getId() {
+		return id;
+	}
+
+	public Points score() {
+
+		if (city == null) {
+			return null;
+		}
+
+		if (balance == null) {
+			return null;
+		}
+
+		return new Points(0)
+				.plus(city.calculatePoints())
+				.plus(balance.calculatePoints());
+	}
+
+	public ApplicationNumber applicationNumber() {
+		return applicationNumber;
+	}
+
+	public ApplicantScoringCluster addCity(String wohnort) {
+
+		this.city = new City(wohnort);
+
+		return this;
+	}
+
+	public ApplicantScoringCluster addBalance(BigDecimal balance) {
+
+		this.balance = new BalanceAtBank(balance);
+
+		return this;
+	}
+}

--- a/src/main/java/com/mploed/aggregate/jmolecules/ApplicationNumber.java
+++ b/src/main/java/com/mploed/aggregate/jmolecules/ApplicationNumber.java
@@ -1,0 +1,13 @@
+package com.mploed.aggregate.jmolecules;
+
+import org.jmolecules.ddd.types.ValueObject;
+
+public record ApplicationNumber(String number) implements ValueObject {
+
+	public ApplicationNumber {
+
+		if (number == null) {
+			throw new IllegalArgumentException("Antragsnummer darf nicht null sein.");
+		}
+	}
+}

--- a/src/main/java/com/mploed/aggregate/jmolecules/BalanceAtBank.java
+++ b/src/main/java/com/mploed/aggregate/jmolecules/BalanceAtBank.java
@@ -1,0 +1,16 @@
+package com.mploed.aggregate.jmolecules;
+
+import java.math.BigDecimal;
+
+import org.jmolecules.ddd.types.ValueObject;
+
+record BalanceAtBank(BigDecimal balance) implements ValueObject {
+
+	public BalanceAtBank(int balance) {
+		this(new BigDecimal(balance));
+	}
+
+	public Points calculatePoints() {
+		return balance.compareTo(new BigDecimal(10000)) == 1 ? new Points(5) : new Points(0);
+	}
+}

--- a/src/main/java/com/mploed/aggregate/jmolecules/City.java
+++ b/src/main/java/com/mploed/aggregate/jmolecules/City.java
@@ -1,0 +1,17 @@
+package com.mploed.aggregate.jmolecules;
+
+import org.jmolecules.ddd.types.ValueObject;
+
+record City(String city) implements ValueObject {
+
+	public Points calculatePoints() {
+
+		if ("Hamburg".equalsIgnoreCase(city)) {
+			return new Points(5);
+		} else if ("München".equalsIgnoreCase(city)) {
+			return new Points(5);
+		} else {
+			return new Points(0);
+		}
+	}
+}

--- a/src/main/java/com/mploed/aggregate/jmolecules/Points.java
+++ b/src/main/java/com/mploed/aggregate/jmolecules/Points.java
@@ -1,0 +1,8 @@
+package com.mploed.aggregate.jmolecules;
+
+public record Points(int points) {
+
+	public Points plus(Points anderePunkte) {
+		return new Points(points + anderePunkte.points);
+	}
+}

--- a/src/main/java/com/mploed/repository/jmolecules/ApplicantScoringClusterJMoleculesRepository.java
+++ b/src/main/java/com/mploed/repository/jmolecules/ApplicantScoringClusterJMoleculesRepository.java
@@ -1,0 +1,14 @@
+package com.mploed.repository.jmolecules;
+
+import org.jmolecules.ddd.types.Repository;
+
+import com.mploed.aggregate.jmolecules.ApplicantScoringCluster;
+import com.mploed.aggregate.jmolecules.ApplicantScoringCluster.ClusterIdentifier;
+import com.mploed.aggregate.jmolecules.ApplicationNumber;
+
+public interface ApplicantScoringClusterJMoleculesRepository extends Repository<ApplicantScoringCluster, ClusterIdentifier> {
+
+	ApplicantScoringCluster save(ApplicantScoringCluster cluster);
+
+	ApplicantScoringCluster findByApplicationNumber(ApplicationNumber antragsnummer);
+}

--- a/src/test/java/com/mploed/repository/jmolecules/JMoleculesTest.java
+++ b/src/test/java/com/mploed/repository/jmolecules/JMoleculesTest.java
@@ -1,0 +1,26 @@
+package com.mploed.repository.jmolecules;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.mploed.aggregate.jmolecules.ApplicantScoringCluster;
+import com.mploed.aggregate.jmolecules.ApplicationNumber;
+
+@SpringBootTest
+class JMoleculesTest {
+
+	@Autowired ApplicantScoringClusterJMoleculesRepository repo;
+
+	@Test
+	void testSave() {
+
+		repo.save(new ApplicantScoringCluster(new ApplicationNumber("152")).addCity("Berlin"));
+
+		var loaded = repo.findByApplicationNumber(new ApplicationNumber("152"));
+
+		assertThat(loaded.applicationNumber()).isEqualTo(new ApplicationNumber("152"));
+	}
+}


### PR DESCRIPTION
This commit adds another persistence approach to the comparison: jMolecules generated persistence using JPA (alternatively, JDBC or MongoDB could be used). The following fundamental steps were taken to add this:

- Added jMolecules BOM to avoid having to declare versions for individual artifacts. We add the `jmolecules-bytebuddy-nodep` dependency and some dedicated JPA support in runtime scope.
- We declare the ByteBuddy Maven plugin to automatically generate persistence metadata post-compilation. It automatically discovers the jMolecules integration (`classPathDiscovery` set to `true`).
- The `jmolecules.config` file restricts the code generation to be applied to the code located in the newly introduced packages to avoid other usage of the jMolecules DDD annotations to trigger code-generation as well. Furthermore, we explicitly select JPA as persistence backend because the project also contains other supported persistence technologies that would get applied if only the general classpath inspection mechanism was active. In a standalone project with only one persistence mechanism, that file would not be necessary.

The two new packages `….aggregate.jmolecules` and `….repository.jmolecules` contain mirrors of the code used in other package, butt significantly cleaned up. Here are the most noteworthy changes:

- The domain model does not contain any of the usual JPA-induced artifacts such as no-argument constructors or fundamental mapping annotations. The persistence metadata is added by the jMolecules ByteBuddy plugin post-compilation. Thus, the source code solely contains business code and the metamodel assignments.
- The value objects are all modeled as Java records, which allows them to get rid of the boilerplate `equals(…)` and `hashCode()` implementations. The persistence code generation makes sure that they're equipped with the necessary metadata and Hibernate customizations to map them.
- The repository interface only extends jMolecules’ `Repository` interface and thus has its type dependency to Spring Data JPA removed. The methods declared still match the conventions established by that, though. The jMolecules code generation automatically adds the Spring Data `Repository` interface to the hierarchy, so that the application repository still works as a Spring Data repository.

## Outcomes

The model is free from persistence-specific references but can still be persisted as is via JPA as persistence mappings can be defaulted from the DDD metamodel information (a type being an aggregate). Thus, as significant downside — the persistence mechanism leaking into the domain model — is avoided. This also works for more complex aggregate arrangements, including references to other aggregates etc.

## Notes

IDEA users have to unfortunately set up the ByteBuddy plugin for execution manually. See the docs here [0].

[0] https://github.com/xmolecules/jmolecules-integrations/tree/main/jmolecules-bytebuddy#quickstart
